### PR TITLE
Fix deploy workflow and wire web to real backend

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'infra/**'
+      - 'web/**'
   workflow_dispatch:
 
 jobs:
@@ -14,9 +15,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    defaults:
-      run:
-        working-directory: infra
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -29,11 +27,18 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Install dependencies
+      - name: Build web app
+        working-directory: web
+        run: npm ci && npm run build
+
+      - name: Install infra dependencies
+        working-directory: infra
         run: npm ci
 
       - name: CDK Diff
+        working-directory: infra
         run: npx cdk diff --all
 
       - name: CDK Deploy
+        working-directory: infra
         run: npx cdk deploy --all --require-approval never


### PR DESCRIPTION
## Summary
- Fix deploy workflow: build web app before CDK deploy (CDN stack needs `web/dist`)
- Also triggers deploy on `web/**` changes (not just `infra/**`)

Previous commits on this branch (already context from PR #22):
- Wire web app to real backend for color analysis
- Use preset season data instead of generating guides per analysis
- Add localhost CORS origins to S3 bucket for dev

## Test plan
- [ ] Merge and verify the deploy workflow succeeds in GitHub Actions
- [ ] Check CDK output for the API URL

https://claude.ai/code/session_01RSFrskDTLrTykH3TQ3gARA