### PR TITLE
Fix CORS: add X-Anonymous-Id to allowed headers

### DIFF
--- a/infra/lib/stacks/ApiStack.ts
+++ b/infra/lib/stacks/ApiStack.ts
@@ -49,7 +49,7 @@ export class ApiStack extends cdk.Stack {
     this.httpApi = new apigatewayv2.HttpApi(this, 'HazelHueApi', {
       apiName: 'hazel-hue-api',
       corsPreflight: {
-        allowHeaders: ['Content-Type', 'Authorization'],
+        allowHeaders: ['Content-Type', 'Authorization', 'X-Anonymous-Id'],
         allowMethods: [
           apigatewayv2.CorsHttpMethod.GET,
           apigatewayv2.CorsHttpMethod.POST,


### PR DESCRIPTION
## Summary
- Add `X-Anonymous-Id` to the CORS `allowHeaders` list in API Gateway
- Without this, the browser blocks requests from the website because the custom header isn't in the CORS preflight response

This fixes the "Failed to fetch" / "Analysis Failed" error on hazelandhue.com.

## Test plan
- [ ] Merge, wait for deploy, then try uploading a photo on hazelandhue.com/analyze

https://claude.ai/code/session_01RSFrskDTLrTykH3TQ3gARA