### PR TITLE
Fix S3 photo upload 403 error

### DIFF
--- a/infra/lambdas/analysis/requestAnalysis.ts
+++ b/infra/lambdas/analysis/requestAnalysis.ts
@@ -44,14 +44,13 @@ export const handler = withMiddleware(async (event) => {
     createdAt: now,
   });
 
-  // Generate presigned upload URL (10MB max, JPEG only)
+  // Generate presigned upload URL (JPEG only)
   const uploadUrl = await getSignedUrl(
     s3,
     new PutObjectCommand({
       Bucket: PHOTO_BUCKET,
       Key: photoKey,
       ContentType: 'image/jpeg',
-      ContentLength: 10_485_760, // 10MB max
     }),
     { expiresIn: 300 }, // 5 minutes
   );


### PR DESCRIPTION
## Summary
- Remove `ContentLength` from the S3 presigned URL generation
- `ContentLength` in `PutObjectCommand` becomes a required exact-match in the signed URL, so every upload fails with 403 since no photo is exactly 10MB

## Test plan
- [ ] Merge, deploy, then upload a photo on hazelandhue.com/analyze

https://claude.ai/code/session_01RSFrskDTLrTykH3TQ3gARA