### PR TITLE
Fix analysis stuck at 85%: allow anonymous userId in SQS

### DIFF
--- a/infra/lambdas/analysis/processAnalysis.ts
+++ b/infra/lambdas/analysis/processAnalysis.ts
@@ -13,7 +13,7 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 
 const analysisMessageSchema = z.object({
   analysisId: z.string().regex(UUID_REGEX),
-  userId: z.string().regex(UUID_REGEX),
+  userId: z.string().min(1).max(256),
   photoKey: z.string().min(1).max(512),
 });
 


### PR DESCRIPTION
## Summary
- Fix processAnalysis Lambda dropping SQS messages from anonymous web users
- The Zod schema required `userId` to match a strict UUID regex, but anonymous users have format `anon_<uuid>` which failed validation
- Messages were silently dropped (logged as "Invalid SQS message" and skipped)

## Test plan
- [ ] Merge, deploy, upload a photo on hazelandhue.com/analyze — should complete past 85%

https://claude.ai/code/session_01RSFrskDTLrTykH3TQ3gARA