### PR TITLE
Fix race condition and remaining analysis integration bugs

### DIFF
--- a/infra/__tests__/stacks/ApiStack.test.ts
+++ b/infra/__tests__/stacks/ApiStack.test.ts
@@ -73,6 +73,7 @@ const canBundle = (() => {
       'POST /analysis',
       'GET /analysis/{id}',
       'GET /analysis/{id}/status',
+      'POST /analysis/{id}/start',
       'POST /analysis/check-quality',
       'POST /recommendation/{id}/guides',
     ];

--- a/infra/lambdas/analysis/processAnalysis.ts
+++ b/infra/lambdas/analysis/processAnalysis.ts
@@ -83,6 +83,10 @@ export const handler = async (event: SQSEvent): Promise<void> => {
     } catch (error) {
       console.error(`Analysis ${analysisId} failed:`, error);
 
+      // Check SQS receive count — only mark as FAILED on the final attempt
+      const receiveCount = parseInt(record.attributes?.ApproximateReceiveCount ?? '1', 10);
+      const maxRetries = 3; // Matches DLQ maxReceiveCount in ApiStack
+
       const failureReason =
         error instanceof Error && error.name === 'AbortError'
           ? 'Analysis timed out — please try again'
@@ -90,13 +94,18 @@ export const handler = async (event: SQSEvent): Promise<void> => {
             ? error.message
             : 'Unknown error';
 
-      await updateItem(`ANALYSIS#${analysisId}`, 'METADATA', {
-        status: 'FAILED',
-        failureReason,
-      });
-      await updateItem(`USER#${userId}`, `ANALYSIS#${analysisId}`, {
-        status: 'FAILED',
-      });
+      if (receiveCount >= maxRetries) {
+        // Final attempt — mark as permanently failed
+        await updateItem(`ANALYSIS#${analysisId}`, 'METADATA', {
+          status: 'FAILED',
+          failureReason,
+        });
+        await updateItem(`USER#${userId}`, `ANALYSIS#${analysisId}`, {
+          status: 'FAILED',
+        });
+      }
+      // Otherwise leave status as PROCESSING so the client doesn't see a premature failure
+
       throw error; // Let SQS retry
     }
   }

--- a/infra/lambdas/analysis/requestAnalysis.ts
+++ b/infra/lambdas/analysis/requestAnalysis.ts
@@ -1,20 +1,15 @@
 import { withMiddleware, getUserIdOrAnonymous } from '../shared/middleware';
 import { putItem } from '../shared/dynamodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { randomUUID } from 'crypto';
 
 const s3 = new S3Client({});
-const sqs = new SQSClient({});
 const PHOTO_BUCKET = process.env.PHOTO_BUCKET!;
-const ANALYSIS_QUEUE_URL = process.env.ANALYSIS_QUEUE_URL!;
+
 
 export const handler = withMiddleware(async (event) => {
   const userId = getUserIdOrAnonymous(event);
-
-  // No entitlement/payment check — Hazel & Hue is free.
-  // Access is gated client-side by the share-to-unlock flow.
 
   const analysisId = randomUUID();
   const photoKey = `photos/${userId}/${analysisId}.jpg`;
@@ -29,7 +24,6 @@ export const handler = withMiddleware(async (event) => {
     status: 'PENDING',
     photoKey,
     createdAt: now,
-    // GSI2: status-based queries
     GSI2PK: 'STATUS#PENDING',
     GSI2SK: now,
   });
@@ -44,7 +38,7 @@ export const handler = withMiddleware(async (event) => {
     createdAt: now,
   });
 
-  // Generate presigned upload URL (JPEG only)
+  // Generate presigned upload URL — accept any image type, we convert client-side
   const uploadUrl = await getSignedUrl(
     s3,
     new PutObjectCommand({
@@ -52,16 +46,11 @@ export const handler = withMiddleware(async (event) => {
       Key: photoKey,
       ContentType: 'image/jpeg',
     }),
-    { expiresIn: 300 }, // 5 minutes
+    { expiresIn: 300 },
   );
 
-  // Queue analysis for async processing
-  await sqs.send(
-    new SendMessageCommand({
-      QueueUrl: ANALYSIS_QUEUE_URL,
-      MessageBody: JSON.stringify({ analysisId, userId, photoKey }),
-    }),
-  );
+  // DO NOT queue SQS here — the client hasn't uploaded the photo yet.
+  // The client will call POST /analysis/{id}/start after uploading.
 
   return {
     statusCode: 201,

--- a/infra/lambdas/analysis/startAnalysis.ts
+++ b/infra/lambdas/analysis/startAnalysis.ts
@@ -1,0 +1,52 @@
+import { withMiddleware, getUserIdOrAnonymous, getPathParamUUID } from '../shared/middleware';
+import { queryItems } from '../shared/dynamodb';
+import { S3Client, HeadObjectCommand } from '@aws-sdk/client-s3';
+import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
+
+const s3 = new S3Client({});
+const sqs = new SQSClient({});
+const PHOTO_BUCKET = process.env.PHOTO_BUCKET!;
+const ANALYSIS_QUEUE_URL = process.env.ANALYSIS_QUEUE_URL!;
+
+export const handler = withMiddleware(async (event) => {
+  const userId = getUserIdOrAnonymous(event);
+  const analysisId = getPathParamUUID(event, 'id');
+
+  // Verify the analysis belongs to this user and is PENDING
+  const items = await queryItems(`USER#${userId}`, `ANALYSIS#${analysisId}`);
+  const analysis = items[0];
+
+  if (!analysis) {
+    throw Object.assign(new Error('Analysis not found'), { statusCode: 404 });
+  }
+
+  if (analysis.status !== 'PENDING') {
+    throw Object.assign(new Error('Analysis already started'), { statusCode: 409 });
+  }
+
+  const photoKey = analysis.photoKey as string;
+
+  // Verify the photo was actually uploaded to S3
+  try {
+    await s3.send(new HeadObjectCommand({ Bucket: PHOTO_BUCKET, Key: photoKey }));
+  } catch {
+    throw Object.assign(new Error('Photo not yet uploaded'), { statusCode: 400 });
+  }
+
+  // Now it's safe to queue the analysis
+  await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: ANALYSIS_QUEUE_URL,
+      MessageBody: JSON.stringify({
+        analysisId,
+        userId,
+        photoKey,
+      }),
+    }),
+  );
+
+  return {
+    statusCode: 200,
+    body: { message: 'Analysis started' },
+  };
+});

--- a/infra/lib/stacks/ApiStack.ts
+++ b/infra/lib/stacks/ApiStack.ts
@@ -131,14 +131,21 @@ export class ApiStack extends cdk.Stack {
     const requestAnalysisFn = new nodejs.NodejsFunction(this, 'RequestAnalysis', {
       ...writeDefaults,
       entry: path.join(__dirname, '../../lambdas/analysis/requestAnalysis.ts'),
+    });
+    table.grantReadWriteData(requestAnalysisFn);
+    photoBucket.grantPut(requestAnalysisFn);
+
+    const startAnalysisFn = new nodejs.NodejsFunction(this, 'StartAnalysis', {
+      ...writeDefaults,
+      entry: path.join(__dirname, '../../lambdas/analysis/startAnalysis.ts'),
       environment: {
         ...lambdaEnv,
         ANALYSIS_QUEUE_URL: this.analysisQueue.queueUrl,
       },
     });
-    table.grantReadWriteData(requestAnalysisFn);
-    photoBucket.grantPut(requestAnalysisFn);
-    this.analysisQueue.grantSendMessages(requestAnalysisFn);
+    table.grantReadData(startAnalysisFn);
+    photoBucket.grantRead(startAnalysisFn);
+    this.analysisQueue.grantSendMessages(startAnalysisFn);
 
     const getResultFn = new nodejs.NodejsFunction(this, 'GetResult', {
       ...readDefaults,
@@ -298,6 +305,12 @@ export class ApiStack extends cdk.Stack {
       path: '/analysis',
       methods: [apigatewayv2.HttpMethod.POST],
       integration: new apigatewayv2Integrations.HttpLambdaIntegration('RequestAnalysis', requestAnalysisFn),
+    });
+
+    this.httpApi.addRoutes({
+      path: '/analysis/{id}/start',
+      methods: [apigatewayv2.HttpMethod.POST],
+      integration: new apigatewayv2Integrations.HttpLambdaIntegration('StartAnalysis', startAnalysisFn),
     });
 
     this.httpApi.addRoutes({

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -58,6 +58,20 @@ export async function uploadPhoto(uploadUrl: string, file: File): Promise<void> 
   }
 }
 
+export async function startAnalysis(analysisId: string): Promise<void> {
+  const res = await fetch(`${getBaseUrl()}/analysis/${analysisId}/start`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Anonymous-Id': getAnonymousId(),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error ?? `Start analysis failed: ${res.status}`);
+  }
+}
+
 export async function pollStatus(analysisId: string): Promise<PollStatusResponse> {
   const res = await fetch(`${getBaseUrl()}/analysis/${analysisId}/status`, {
     headers: { 'X-Anonymous-Id': getAnonymousId() },

--- a/web/src/components/AnalysisLoading.tsx
+++ b/web/src/components/AnalysisLoading.tsx
@@ -1,6 +1,5 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { useEffect, useRef, useState } from 'react';
-import { pollStatus } from '../api/client';
 
 const ANALYSIS_STEPS = [
   { label: 'Uploading your photo', minDuration: 1500 },
@@ -16,39 +15,19 @@ interface Props {
   analysisId: string | null;
 }
 
-export function AnalysisLoading({ preview, analysisId }: Props) {
+export function AnalysisLoading({ preview }: Props) {
   const [currentStep, setCurrentStep] = useState(0);
   const [progress, setProgress] = useState(0);
-  const [backendDone, setBackendDone] = useState(false);
   const startTimeRef = useRef(Date.now());
 
-  // Poll for real status
-  useEffect(() => {
-    if (!analysisId) return;
-
-    const interval = setInterval(async () => {
-      try {
-        const result = await pollStatus(analysisId);
-        if (result.status === 'COMPLETED' || result.status === 'FAILED') {
-          setBackendDone(true);
-          clearInterval(interval);
-        }
-      } catch {
-        // Polling errors are non-fatal
-      }
-    }, 2000);
-
-    return () => clearInterval(interval);
-  }, [analysisId]);
-
-  // Animate progress
+  // Animate progress — caps at 90% and loops through steps.
+  // AnalysisPage handles polling and will unmount this component when done.
   useEffect(() => {
     const totalDuration = ANALYSIS_STEPS.reduce((s, st) => s + st.minDuration, 0);
 
     const interval = setInterval(() => {
       const elapsed = Date.now() - startTimeRef.current;
 
-      // Calculate current step
       let accumulated = 0;
       let step = 0;
       for (let i = 0; i < ANALYSIS_STEPS.length; i++) {
@@ -61,19 +40,13 @@ export function AnalysisLoading({ preview, analysisId }: Props) {
       }
       setCurrentStep(step);
 
-      // Progress caps at 85% until backend is done
-      const rawPct = Math.min((elapsed / totalDuration) * 85, 85);
-
-      if (backendDone) {
-        // Quickly fill to 100%
-        setProgress((prev) => Math.min(prev + 3, 100));
-      } else {
-        setProgress(rawPct);
-      }
+      // Ease toward 90% — never reaches 100% (parent transitions on completion)
+      const rawPct = Math.min((elapsed / totalDuration) * 85, 90);
+      setProgress(rawPct);
     }, 80);
 
     return () => clearInterval(interval);
-  }, [backendDone]);
+  }, []);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-cream px-6">

--- a/web/src/components/AnalysisPage.tsx
+++ b/web/src/components/AnalysisPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 import { PhotoUpload } from './PhotoUpload';
 import { AnalysisLoading } from './AnalysisLoading';
 import { AnalysisResults } from './AnalysisResults';
-import { requestAnalysis, uploadPhoto, pollStatus } from '../api/client';
+import { requestAnalysis, uploadPhoto, startAnalysis, pollStatus } from '../api/client';
 import { SEASON_DATA } from '../data/seasons';
 import type { SeasonResult, SeasonType } from '../data/seasons';
 
@@ -20,6 +20,37 @@ const SEASON_ID_TO_DISPLAY: Record<string, SeasonType> = {
   TRUE_WINTER: 'True Winter',
   BRIGHT_WINTER: 'Bright Winter',
 };
+
+/**
+ * Convert any image file to JPEG via canvas.
+ * The presigned S3 URL requires Content-Type: image/jpeg.
+ */
+function convertToJpeg(file: File): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    if (file.type === 'image/jpeg') {
+      resolve(file);
+      return;
+    }
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext('2d')!;
+      ctx.drawImage(img, 0, 0);
+      canvas.toBlob(
+        (blob) => {
+          if (blob) resolve(blob);
+          else reject(new Error('Failed to convert image to JPEG'));
+        },
+        'image/jpeg',
+        0.92,
+      );
+    };
+    img.onerror = () => reject(new Error('Failed to load image'));
+    img.src = URL.createObjectURL(file);
+  });
+}
 
 type Step = 'upload' | 'analyzing' | 'results' | 'error';
 
@@ -48,13 +79,23 @@ export function AnalysisPage() {
 
       if (abort.signal.aborted) return;
 
-      // 2. Upload photo to S3 via presigned URL
-      await uploadPhoto(uploadUrl, file);
+      // 2. Convert to JPEG (presigned URL expects image/jpeg)
+      const jpegBlob = await convertToJpeg(file);
 
       if (abort.signal.aborted) return;
 
-      // 3. Poll for completion
-      const maxPolls = 60; // 60 * 2s = 2 minutes max
+      // 3. Upload JPEG to S3 via presigned URL
+      await uploadPhoto(uploadUrl, new File([jpegBlob], 'photo.jpg', { type: 'image/jpeg' }));
+
+      if (abort.signal.aborted) return;
+
+      // 4. Tell backend the photo is uploaded — triggers SQS processing
+      await startAnalysis(analysisId);
+
+      if (abort.signal.aborted) return;
+
+      // 5. Poll for completion
+      const maxPolls = 90; // 90 * 2s = 3 minutes max
       for (let i = 0; i < maxPolls; i++) {
         if (abort.signal.aborted) return;
 
@@ -64,7 +105,6 @@ export function AnalysisPage() {
         const status = await pollStatus(analysisId);
 
         if (status.status === 'COMPLETED' && status.season) {
-          // Look up preset results by season — no extra API call needed
           const displaySeason = SEASON_ID_TO_DISPLAY[status.season];
           if (!displaySeason || !SEASON_DATA[displaySeason]) {
             throw new Error(`Unknown season: ${status.season}`);


### PR DESCRIPTION
## Summary
- **Fix "key does not exist" S3 error**: Created new `startAnalysis` Lambda (`POST /analysis/{id}/start`) that the client calls AFTER uploading the photo. It verifies the photo exists in S3 before queuing the SQS message, eliminating the race condition where processing started before upload completed.
- **Fix image format mismatch**: Added client-side JPEG conversion via canvas so PNG, HEIC, and WebP uploads are converted before sending to S3 (presigned URL requires `image/jpeg`).
- **Fix duplicate polling**: Removed independent polling from `AnalysisLoading` component — `AnalysisPage` already handles polling and state transitions. Loading screen now shows purely cosmetic progress animation.
- **Cleanup**: Removed unused SQS imports/env vars from `requestAnalysis`, updated ApiStack test for new public route.

## Test plan
- [ ] Upload a JPEG selfie — should complete analysis successfully
- [ ] Upload a PNG/HEIC image — should auto-convert to JPEG and complete
- [ ] Verify loading screen animates smoothly and transitions to results
- [ ] Verify no "key does not exist" errors in CloudWatch logs
- [ ] Verify `POST /analysis/{id}/start` returns 400 if photo not yet uploaded

https://claude.ai/code/session_01RSFrskDTLrTykH3TQ3gARA