### PR TITLE
Fix Bedrock: use inference profile for Claude Sonnet 4

### DIFF
--- a/infra/lambdas/analysis/processAnalysis.ts
+++ b/infra/lambdas/analysis/processAnalysis.ts
@@ -132,7 +132,7 @@ async function invokeClaudeVision(imageBase64: string, prompt: string): Promise<
   try {
     const response = await bedrock.send(
       new InvokeModelCommand({
-        modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        modelId: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
         contentType: 'application/json',
         accept: 'application/json',
         body: JSON.stringify({

--- a/infra/lib/stacks/ProcessingStack.ts
+++ b/infra/lib/stacks/ProcessingStack.ts
@@ -45,12 +45,13 @@ export class ProcessingStack extends cdk.Stack {
     table.grantReadWriteData(processAnalysisFn);
     photoBucket.grantRead(processAnalysisFn);
 
-    // Bedrock access — scoped to specific model
+    // Bedrock access — use cross-region inference profile (required for Claude Sonnet 4)
     processAnalysisFn.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ['bedrock:InvokeModel'],
         resources: [
-          `arn:aws:bedrock:${this.region}::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0`,
+          `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-sonnet-4-20250514-v1:0`,
+          `arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0`,
         ],
       }),
     );


### PR DESCRIPTION
## Summary
- Claude Sonnet 4 cannot be invoked directly via model ID with on-demand throughput in Bedrock. It requires a **cross-region inference profile**.
- Updated model ID from `anthropic.claude-sonnet-4-20250514-v1:0` to `us.anthropic.claude-sonnet-4-20250514-v1:0`
- Updated IAM policy to allow the inference profile ARN + foundation model ARN

## Test plan
- [ ] Upload a selfie and verify analysis completes with a season result
- [ ] No more "Invocation of model ID... isn't supported" error

https://claude.ai/code/session_01RSFrskDTLrTykH3TQ3gARA