### PR TITLE
Switch to Claude 3.5 Sonnet v2 for Bedrock analysis

### DIFF
--- a/infra/lambdas/analysis/processAnalysis.ts
+++ b/infra/lambdas/analysis/processAnalysis.ts
@@ -132,7 +132,7 @@ async function invokeClaudeVision(imageBase64: string, prompt: string): Promise<
   try {
     const response = await bedrock.send(
       new InvokeModelCommand({
-        modelId: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+        modelId: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
         contentType: 'application/json',
         accept: 'application/json',
         body: JSON.stringify({

--- a/infra/lib/stacks/ProcessingStack.ts
+++ b/infra/lib/stacks/ProcessingStack.ts
@@ -45,13 +45,13 @@ export class ProcessingStack extends cdk.Stack {
     table.grantReadWriteData(processAnalysisFn);
     photoBucket.grantRead(processAnalysisFn);
 
-    // Bedrock access — use cross-region inference profile (required for Claude Sonnet 4)
+    // Bedrock access — use cross-region inference profile for Claude 3.5 Sonnet v2
     processAnalysisFn.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ['bedrock:InvokeModel'],
         resources: [
-          `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-sonnet-4-20250514-v1:0`,
-          `arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0`,
+          `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0`,
+          `arn:aws:bedrock:*::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0`,
         ],
       }),
     );


### PR DESCRIPTION
## Summary
- Switch from Claude Sonnet 4 to Claude 3.5 Sonnet v2 for color analysis
- Claude Sonnet 4 requires AWS Marketplace subscription that has permission issues even for root accounts
- Claude 3.5 Sonnet v2 is equally capable for image-based color analysis and widely accessible

## Test plan
- [ ] Upload a selfie and verify the analysis completes with a season result

https://claude.ai/code/session_01RSFrskDTLrTykH3TQ3gARA