### PR TITLE
Switch to Claude 3.7 Sonnet (non-legacy active model)

### DIFF
--- a/infra/lambdas/analysis/processAnalysis.ts
+++ b/infra/lambdas/analysis/processAnalysis.ts
@@ -132,7 +132,7 @@ async function invokeClaudeVision(imageBase64: string, prompt: string): Promise<
   try {
     const response = await bedrock.send(
       new InvokeModelCommand({
-        modelId: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+        modelId: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
         contentType: 'application/json',
         accept: 'application/json',
         body: JSON.stringify({

--- a/infra/lib/stacks/ProcessingStack.ts
+++ b/infra/lib/stacks/ProcessingStack.ts
@@ -45,13 +45,13 @@ export class ProcessingStack extends cdk.Stack {
     table.grantReadWriteData(processAnalysisFn);
     photoBucket.grantRead(processAnalysisFn);
 
-    // Bedrock access — use cross-region inference profile for Claude 3.5 Sonnet v2
+    // Bedrock access — Claude 3.7 Sonnet via cross-region inference profile
     processAnalysisFn.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ['bedrock:InvokeModel'],
         resources: [
-          `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0`,
-          `arn:aws:bedrock:*::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0`,
+          `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0`,
+          `arn:aws:bedrock:*::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0`,
         ],
       }),
     );

--- a/infra/lib/stacks/ProcessingStack.ts
+++ b/infra/lib/stacks/ProcessingStack.ts
@@ -56,6 +56,18 @@ export class ProcessingStack extends cdk.Stack {
       }),
     );
 
+    // AWS Marketplace permissions — required for first-time model auto-enablement
+    processAnalysisFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: [
+          'aws-marketplace:Subscribe',
+          'aws-marketplace:Unsubscribe',
+          'aws-marketplace:ViewSubscriptions',
+        ],
+        resources: ['*'],
+      }),
+    );
+
     // Rekognition access for face detection
     // Note: DetectFaces does not support resource-level permissions (AWS limitation)
     processAnalysisFn.addToRolePolicy(


### PR DESCRIPTION
## Summary
- Claude 3.5 Sonnet v2 is marked as Legacy on Bedrock and blocked for new usage
- Switch to Claude 3.7 Sonnet which is the current active model with strong vision capabilities

## Test plan
- [ ] Upload a selfie and verify analysis completes with a season result

https://claude.ai/code/session_01RSFrskDTLrTykH3TQ3gARA