### PR TITLE
Switch back to Claude Sonnet 4 (only active non-legacy model)

### DIFF
--- a/infra/lambdas/analysis/processAnalysis.ts
+++ b/infra/lambdas/analysis/processAnalysis.ts
@@ -132,7 +132,7 @@ async function invokeClaudeVision(imageBase64: string, prompt: string): Promise<
   try {
     const response = await bedrock.send(
       new InvokeModelCommand({
-        modelId: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
+        modelId: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
         contentType: 'application/json',
         accept: 'application/json',
         body: JSON.stringify({

--- a/infra/lib/stacks/ProcessingStack.ts
+++ b/infra/lib/stacks/ProcessingStack.ts
@@ -45,13 +45,13 @@ export class ProcessingStack extends cdk.Stack {
     table.grantReadWriteData(processAnalysisFn);
     photoBucket.grantRead(processAnalysisFn);
 
-    // Bedrock access — Claude 3.7 Sonnet via cross-region inference profile
+    // Bedrock access — Claude Sonnet 4 via cross-region inference profile
     processAnalysisFn.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ['bedrock:InvokeModel'],
         resources: [
-          `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0`,
-          `arn:aws:bedrock:*::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0`,
+          `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-sonnet-4-20250514-v1:0`,
+          `arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0`,
         ],
       }),
     );


### PR DESCRIPTION
Claude 3.5 Sonnet v2 and 3.7 Sonnet are both marked as Legacy on Bedrock. Claude Sonnet 4 is the only active model. The marketplace permissions added in the previous commit should resolve the earlier subscription issue.

https://claude.ai/code/session_01RSFrskDTLrTykH3TQ3gARA