### PR TITLE
Fix inconsistent season results with deterministic prompt

### DIFF
--- a/infra/lambdas/analysis/processAnalysis.ts
+++ b/infra/lambdas/analysis/processAnalysis.ts
@@ -137,8 +137,9 @@ async function invokeClaudeVision(imageBase64: string, prompt: string): Promise<
         accept: 'application/json',
         body: JSON.stringify({
           anthropic_version: 'bedrock-2023-05-31',
-          max_tokens: 4096,
-          temperature: 0, // Deterministic for classification accuracy
+          max_tokens: 2048,
+          temperature: 0,
+          top_k: 1, // Maximum determinism — always pick the top token
           system: COLORIST_SYSTEM_PROMPT,
           messages: [
             {
@@ -166,117 +167,61 @@ async function invokeClaudeVision(imageBase64: string, prompt: string): Promise<
 
 // ─── Prompts ─────────────────────────────────────────────────────
 
-const COLORIST_SYSTEM_PROMPT = `You are a world-class personal color analyst trained in the Sci/ART method (developed by Kathryn Kalisz from the Munsell Institute). You combine professional draping methodology with rigorous color science — Munsell color system (Hue, Value, Chroma as independent perceptual dimensions) and CIE L*a*b* color space for precise measurement. You understand dermatological undertone assessment, the perceptual science of simultaneous contrast, and the continuous 12-season flow chart where adjacent "sister seasons" share a dominant characteristic. You are methodical, precise, and never guess — you analyze each dimension independently before combining. Any person of any ethnicity can be any season; you assess undertone, not skin depth. Always respond with valid JSON matching the requested schema.`;
+const COLORIST_SYSTEM_PROMPT = `You are a professional 12-season color analyst using the Sci/ART method. You classify people into exactly one of 12 seasons based on their natural coloring. You focus on the person's inherent skin undertone, hair color, and eye color — ignoring makeup, lighting artifacts, and filters as much as possible. Any ethnicity can be any season. You always respond with valid JSON only.`;
 
-const CLASSIFICATION_PROMPT = `You are performing a professional 12-season color analysis on this person's photo using the Sci/ART methodology. Follow this rigorous step-by-step process:
+const CLASSIFICATION_PROMPT = `Classify this person into one of 12 color seasons. Follow this EXACT decision tree — commit to each answer before moving to the next step.
 
-## STEP 1: ASSESS LIGHTING CONDITIONS
-Before analyzing coloring, evaluate the photo's lighting:
-- Is it daylight, warm indoor light, cool fluorescent, or mixed?
-- Is the white balance neutral or shifted warm/cool?
-- Are there strong color casts from clothing or background?
-- Mentally compensate for any non-neutral lighting when assessing skin undertone. If the photo has warm/orange lighting, the skin will appear warmer than it naturally is — adjust accordingly.
+DECISION TREE:
 
-## STEP 2: EXTRACT COLOR DATA (CIE L*a*b* framework)
-Sample the dominant colors from three regions, thinking in perceptual terms:
+1. SKIN UNDERTONE (most important — look at inner wrist, jawline, forehead):
+   - Golden/peachy/yellow base → WARM
+   - Pink/rosy/blue base → COOL
+   - Olive: look beneath — yellow-olive = WARM, gray-olive = COOL
 
-- **Skin**: Sample from forehead, cheek, and jawline (avoiding shadowed areas and areas affected by redness/blemishes). Determine the BASE undertone beneath any surface overtone:
-  - Yellow/golden/peachy base → warm undertone (higher b* in Lab space)
-  - Pink/rosy/blue base → cool undertone (higher a* relative to b*)
-  - Olive: look BENEATH the olive cast — olive can be warm-olive (yellow base) OR cool-olive (blue-gray base)
-  - Note the Munsell Value (lightness: very fair → very deep) and Chroma (how saturated/clear vs. muted/grayed the skin appears)
+2. OVERALL DEPTH (combine skin + hair + eyes):
+   - Fair skin + light hair + light eyes → LIGHT
+   - Dark hair + deep features → DEEP
+   - Neither extreme → MEDIUM
 
-- **Hair**: Sample from root/mid-shaft (most natural area). Classify:
-  - Temperature: golden/auburn/copper/strawberry/warm brown = warm; ash/cool brown/blue-black = cool; medium brown with no strong cast = neutral
-  - Depth: light (blonde range), medium (brown range), deep (dark brown to black)
-  - Clarity: does the hair look rich and clear, or dusty and muted?
+3. CHROMA (how vivid/saturated are the features?):
+   - Vivid eye color, clear skin, high-definition features → BRIGHT
+   - Dusty, blended, grayed-down, soft-focus features → SOFT/MUTED
+   - Neither extreme → MODERATE
 
-- **Eyes**: Identify the dominant iris color and patterns:
-  - Warm indicators: golden/amber flecks, warm brown, green with gold, hazel with warm tones
-  - Cool indicators: icy blue, steel gray, cool dark brown/espresso, green with gray
-  - Note saturation: vivid/jewel-like eyes = high chroma; grayed/blended eyes = low chroma
+4. MAP using this table (pick the BEST match):
 
-## STEP 3: DETERMINE THE THREE MUNSELL DIMENSIONS
-These three perceptually independent dimensions are the scientific basis for the 12-season system:
+   | Season         | Undertone | Depth  | Chroma   | Key Indicator                           |
+   |----------------|-----------|--------|----------|-----------------------------------------|
+   | LIGHT_SPRING   | Warm      | Light  | Moderate | Delicate warm coloring, peachy skin     |
+   | TRUE_SPRING    | Warm      | Medium | Bright   | Unmistakable golden warmth throughout   |
+   | BRIGHT_SPRING  | Warm      | Any    | Bright   | High contrast + vivid + warm undertone  |
+   | LIGHT_SUMMER   | Cool      | Light  | Moderate | Delicate cool coloring, rosy/pink skin  |
+   | TRUE_SUMMER    | Cool      | Medium | Soft     | Cool + muted, ash tones throughout      |
+   | SOFT_SUMMER    | Cool      | Medium | Soft     | Very muted, neutral-cool, blended       |
+   | SOFT_AUTUMN    | Warm      | Medium | Soft     | Very muted, neutral-warm, blended       |
+   | TRUE_AUTUMN    | Warm      | Medium | Moderate | Rich earthy warmth, golden/olive skin   |
+   | DEEP_AUTUMN    | Warm      | Deep   | Moderate | Dark features with warm/golden cast      |
+   | DEEP_WINTER    | Cool      | Deep   | Moderate | Dark features with cool/blue cast        |
+   | TRUE_WINTER    | Cool      | Medium | Bright   | Cool + clear, high contrast              |
+   | BRIGHT_WINTER  | Cool      | Any    | Bright   | Highest contrast + vivid + cool undertone|
 
-1. **HUE → Temperature (Warm vs Cool)**
-   The MOST important dimension — determines the season family (Spring/Autumn = warm, Summer/Winter = cool).
-   - Skin undertone is the primary indicator. Hair and eye temperature should confirm, but skin undertone takes precedence.
-   - If skin reads clearly warm or cool, classify accordingly.
-   - If neutral/ambiguous, look at whether warm or cool colors in their features dominate overall.
+CONSISTENCY RULES:
+- The undertone MUST match the season family: Spring/Autumn = Warm, Summer/Winter = Cool.
+- If torn between two sister seasons, skin undertone is the tiebreaker.
+- Ignore clothing and background colors.
+- If you detect makeup or hair dye, try to assess NATURAL coloring beneath.
 
-2. **VALUE → Depth (Light vs Medium vs Deep)**
-   Assess the OVERALL lightness/darkness of all features combined:
-   - Light: fair skin + lighter hair + lighter eyes (features float toward the light end of the value scale)
-   - Medium: moderate depth across features (neither strikingly light nor dark)
-   - Deep: dark hair + deeper skin tone + darker eyes (features cluster toward the dark end)
-
-3. **CHROMA → Clarity (Bright/Clear vs Soft/Muted)**
-   How saturated, vivid, and pure are the features?
-   - Bright/Clear: vivid eye color, clear skin, features look "HD" and distinct. High color intensity.
-   - Soft/Muted: dusty, blended, grayed-down coloring. Features seem to blend together rather than stand out individually. Lower color intensity.
-
-   Natural correlations to be aware of (but don't assume — verify):
-   - Warm + Light tends toward higher chroma naturally (Spring)
-   - Cool + Light tends toward lower chroma naturally (Summer)
-   - Warm + Dark tends toward lower chroma naturally (Autumn)
-   - Cool + Dark tends toward higher chroma naturally (Winter)
-
-## STEP 4: DETERMINE CONTRAST LEVEL
-Contrast = the VALUE difference between the lightest and darkest features (typically skin vs hair):
-- **Low contrast**: Hair, skin, and eyes are similar in depth. Features blend together.
-- **Medium contrast**: Moderate difference between features.
-- **High contrast**: Stark difference — e.g., very dark hair with very light skin, or very light eyes against dark features.
-
-## STEP 5: MAP TO ONE OF 12 SEASONS
-Each season has a **dominant** characteristic (the most important trait) and a **secondary** one. The 12 seasons form a continuous cycle — adjacent seasons are "sister seasons" that share their dominant trait:
-
-**SPRING (Warm base) — warm undertone is present in all Springs**
-- LIGHT_SPRING: Dominant = Light, Secondary = Warm. Very fair, delicate warm coloring. Low contrast. Light golden/honey hair, light warm eyes (blue-green, light hazel, light warm brown), peachy/ivory skin with warm glow. Sister to Light Summer (both light, but this one is warm).
-- TRUE_SPRING: Dominant = Warm, Secondary = Clear. The purest warm season. Medium value, clear saturated warmth throughout. Golden/strawberry/warm brown hair, warm green/hazel/topaz eyes, golden-peachy skin. Warmth is unmistakable.
-- BRIGHT_SPRING: Dominant = Bright/Clear, Secondary = Warm. High chroma + warm lean. Can have dark hair with light warm skin (high contrast). Vivid, saturated, "electric" coloring. Striking eye color. Sister to Bright Winter (both bright, but this one is warm).
-
-**SUMMER (Cool base) — cool undertone is present in all Summers**
-- LIGHT_SUMMER: Dominant = Light, Secondary = Cool. Very fair, delicate cool coloring. Low contrast. Ash-blonde/light ash-brown hair, light cool eyes (soft blue, gray-blue, light cool gray), rosy/pink-toned skin. Sister to Light Spring (both light, but this one is cool).
-- TRUE_SUMMER: Dominant = Cool, Secondary = Soft. The purest cool muted season. Medium-light value. Ash-toned/cool brown hair, cool blue/gray/soft green eyes, pink-toned/rosy skin with blue undertone. Coolness is the defining trait.
-- SOFT_SUMMER: Dominant = Soft/Muted, Secondary = Cool. Most muted cool season. Blended, low-contrast, neutral-cool. Mousy/ash-brown hair, grayed/muted eyes (gray, gray-green, soft hazel), neutral-cool skin. Features seem "soft-focus." Sister to Soft Autumn (both muted, but this one leans cool).
-
-**AUTUMN (Warm base) — warm undertone is present in all Autumns**
-- SOFT_AUTUMN: Dominant = Soft/Muted, Secondary = Warm. Most muted warm season. Blended, low-contrast, neutral-warm. Golden-brown/mousy hair, hazel/warm muted green/amber eyes, warm but muted skin. Features are "soft-focus" with warmth. Sister to Soft Summer (both muted, but this one leans warm).
-- TRUE_AUTUMN: Dominant = Warm, Secondary = Rich/Earthy. The purest warm muted season. Medium-dark value. Rich auburn/chestnut/warm brown hair, warm brown/green/hazel eyes, golden/warm olive skin. Rich warmth without high clarity.
-- DEEP_AUTUMN: Dominant = Deep/Dark, Secondary = Warm. Dark + warm. Deep brown/black hair with warm or golden cast, dark warm brown/deep hazel eyes, olive/warm deeper skin tones. Rich depth with warm undertone. Sister to Deep Winter (both deep, but this one is warm).
-
-**WINTER (Cool base) — cool undertone is present in all Winters**
-- DEEP_WINTER: Dominant = Deep/Dark, Secondary = Cool. Dark + cool. Very dark hair (cool brown to black), dark cool brown/near-black eyes, deeper skin with cool or neutral-cool undertone. Dramatic depth without warmth. Sister to Deep Autumn (both deep, but this one is cool).
-- TRUE_WINTER: Dominant = Cool, Secondary = Clear. The purest cool bright season. High contrast between features. Dark cool hair, striking cool eyes (deep brown, icy blue, cool gray), porcelain to deep skin with distinctly cool/blue undertone. Coolness and clarity define this season.
-- BRIGHT_WINTER: Dominant = Bright/Clear, Secondary = Cool. Highest chroma + cool. The most vivid season. Very high contrast. Dark hair + very light skin OR deep skin with remarkably vivid/saturated features. Jewel-like eye color. Sister to Bright Spring (both bright, but this one is cool).
-
-## STEP 6: DISTINGUISH SISTER SEASONS (CRITICAL)
-If you're torn between two adjacent seasons, use these tiebreakers:
-- **Light Spring vs Light Summer**: Does skin lean peachy-warm or rosy-cool? Does hair have golden or ash tones?
-- **Bright Spring vs Bright Winter**: Do warm or cool drape colors theoretically flatter more? Is the undertone golden or pink?
-- **Soft Summer vs Soft Autumn**: Same mutedness — is the underlying cast cool-gray or warm-golden?
-- **Deep Autumn vs Deep Winter**: Same darkness — does the depth have a warm/golden cast or a cool/blue cast?
-- **True Spring vs True Autumn**: Both warm — Spring is clearer/lighter, Autumn is more muted/deeper/earthier.
-- **True Summer vs True Winter**: Both cool — Summer is softer/muted, Winter is clearer/more saturated.
-
-## STEP 7: FINAL CROSS-CHECK
-- Verify your classification is internally consistent: does the dominant characteristic genuinely dominate?
-- Season applies regardless of ethnicity — focus on undertone, not skin depth. A person with deep skin can be a Spring; a person with fair skin can be a Winter.
-- If you detect makeup, hair dye, or colored contacts, try to assess the NATURAL coloring beneath.
-- Lower your confidence score when: lighting is poor, heavy makeup is present, hair appears dyed, or the person sits ambiguously between sister seasons.
-
-Respond with ONLY valid JSON in this exact format:
+Respond with ONLY this JSON — no other text:
 {
-  "season": "<one of: LIGHT_SPRING, TRUE_SPRING, BRIGHT_SPRING, LIGHT_SUMMER, TRUE_SUMMER, SOFT_SUMMER, SOFT_AUTUMN, TRUE_AUTUMN, DEEP_AUTUMN, DEEP_WINTER, TRUE_WINTER, BRIGHT_WINTER>",
+  "season": "<LIGHT_SPRING|TRUE_SPRING|BRIGHT_SPRING|LIGHT_SUMMER|TRUE_SUMMER|SOFT_SUMMER|SOFT_AUTUMN|TRUE_AUTUMN|DEEP_AUTUMN|DEEP_WINTER|TRUE_WINTER|BRIGHT_WINTER>",
   "confidenceScore": <0-100>,
   "colorProfile": {
-    "undertone": "<warm|cool|neutral>",
-    "chroma": "<bright|soft|muted>",
+    "undertone": "<warm|cool>",
+    "chroma": "<bright|soft|moderate>",
     "contrastLevel": "<low|medium|high>",
-    "dominantSkinHex": "<hex color sampled from cheek area>",
-    "dominantHairHex": "<hex color sampled from mid-shaft>",
-    "dominantEyeHex": "<hex color sampled from iris>"
+    "dominantSkinHex": "<hex>",
+    "dominantHairHex": "<hex>",
+    "dominantEyeHex": "<hex>"
   },
-  "reasoning": "<detailed explanation covering: (1) lighting assessment and any compensation applied, (2) skin undertone analysis — what hue/base do you see beneath the surface?, (3) hair temperature and depth, (4) eye color, saturation, and temperature, (5) overall contrast level, (6) the three Munsell dimensions (temperature/value/chroma) and which is dominant, (7) if sister seasons were considered, why this one won>"
+  "reasoning": "<2-3 sentences: what undertone you see, what depth, what chroma, and why this season>"
 }`;


### PR DESCRIPTION
## Summary
Fixes inconsistent season classifications across similar photos of the same person.

**Root cause**: The previous prompt had a 7-step open-ended reasoning chain. Even at temperature 0, the model could take different reasoning paths on similar images, producing different season results.

**Changes**:
- **Structured decision tree** — forces the model through a fixed sequence: undertone → depth → chroma → table lookup. No room for divergent reasoning.
- **`top_k: 1`** — maximum token-level determinism (always picks the highest probability token)
- **Season lookup table** — explicit mapping from features to season instead of prose descriptions
- **Shorter reasoning output** (2-3 sentences vs paragraphs) — less surface area for variance
- **Consistency rules** — undertone must match season family (warm = Spring/Autumn, cool = Summer/Winter)
- **Reduced `max_tokens`** from 4096 to 2048

## Test plan
- [ ] Upload the same photo 3 times — should get the same season each time
- [ ] Upload similar photos (same person, similar lighting) — should get same or adjacent season

https://claude.ai/code/session_01RSFrskDTLrTykH3TQ3gARA